### PR TITLE
Fix character JSON import/export click handling

### DIFF
--- a/js/base-character-io.js
+++ b/js/base-character-io.js
@@ -2,7 +2,10 @@ function baseCharacterIo () {
 	d20plus.characterIo = {};
 
 	const getCharacterFromEvent = (event) => {
-		const cId = $(event.currentTarget).closest(`[data-characterid]`).attr(`data-characterid`);
+		const $target = $(event.target);
+		const $characterRoot = $target.closest(`[data-characterid]`);
+		const $fallbackRoot = $characterRoot.length ? $characterRoot : $(event.currentTarget).closest(`[data-characterid]`);
+		const cId = $fallbackRoot.attr(`data-characterid`);
 		if (!cId) return null;
 		return d20.Campaign.characters.get(cId);
 	};
@@ -96,11 +99,11 @@ function baseCharacterIo () {
 				const character = getCharacterFromEvent(event);
 				if (!character) return alert("No character found.");
 
-				const $input = $(`<input type="file" accept="application/json">`);
+				const $input = $(`<input type="file" accept="application/json">`).appendTo("body");
 				$input.on("change", () => {
 					const fileList = $input[0] && $input[0].files;
 					const file = fileList && fileList[0];
-					if (!file) return;
+					if (!file) return $input.remove();
 
 					const reader = new FileReader();
 					reader.onload = () => {
@@ -109,20 +112,26 @@ function baseCharacterIo () {
 							payload = JSON.parse(reader.result);
 						} catch (err) {
 							alert("Invalid JSON file.");
+							$input.remove();
 							return;
 						}
 
 						const entry = getImportEntry(payload);
 						if (!entry || !entry.attribs) {
 							alert("No character data found in this JSON file.");
+							$input.remove();
 							return;
 						}
 
 						const name = (entry.attributes && entry.attributes.name) || character.get("name");
-						if (!confirm(`Import JSON into "${character.get("name")}"? This will overwrite the sheet data with "${name}".`)) return;
+						if (!confirm(`Import JSON into "${character.get("name")}"? This will overwrite the sheet data with "${name}".`)) {
+							$input.remove();
+							return;
+						}
 
 						applyCharacterImport(character, entry);
 						alert(`Imported JSON into "${character.get("name")}".`);
+						$input.remove();
 					};
 					reader.readAsText(file);
 				});


### PR DESCRIPTION
### Motivation
- The delegated JSON import/export buttons were not reliably locating the correct character when inner elements were clicked, preventing the handlers from acting on the intended sheet.
- Temporary file input elements created for importing were not removed on all code paths, leaving stray inputs in the DOM after cancelled/failed imports.

### Description
- Updated `getCharacterFromEvent` to prefer the actual click target by using `event.target` and `closest('[data-characterid]')`, with a fallback to `event.currentTarget`, to reliably resolve the `data-characterid` for delegated clicks.
- Appended the temporary file input to the document (`.appendTo("body")`) so the file picker reliably opens across contexts.
- Ensured the temporary file input is removed (`$input.remove()`) on all early-exit paths including no file selected, invalid JSON, missing character data, and user cancelation of the confirm dialog.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970c79cad0083338df291a3298216e3)